### PR TITLE
Update example environment to include fsek.1337s

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,4 +4,4 @@ AUTH_KEYCLOAK_SECRET= # Depends on Keycloak setup
 AUTH_KEYCLOAK_ISSUER= # Depends on Keycloak setup, https://url.example.com/realms/[realmname]
 DB_URL=file:src/lib/server/db/sqlite.db
 AUTH_TRUST_HOST=true
-ADMIN_GROUPS="dsek.cpu.utvecklare dsek.cpu.mastare" # Keycloak groups with admin access, separated by spaces
+ADMIN_GROUPS="dsek.cpu.utvecklare dsek.cpu.mastare fsek.1337s" # Keycloak groups with admin access, separated by spaces


### PR DESCRIPTION
In order to allow the @1337s from the F-guild to administer the whitelist of the minecraft server they have to be added to the list of admin groups.